### PR TITLE
Fix crash after long running use of lruset (python version)

### DIFF
--- a/lruset.py
+++ b/lruset.py
@@ -35,8 +35,10 @@ class LRUSet(object):
                 # linked list.
                 node.previous.next = node.next
                 node.next.previous = node.previous
+                node.previous = self._tail
                 self._tail.next = node
                 self._tail = node
+                node.next = None
             else:
                 self.remove(item)
                 self.add(item)
@@ -75,6 +77,7 @@ class LRUSet(object):
             # performance (~8-9% improvement).
             del self._lookup_table[self._head.value]
             self._head = self._head.next
+            self._head.previous = None
             self.current_size -= 1
 
     def remove(self, item):
@@ -84,8 +87,16 @@ class LRUSet(object):
         # be removed.
         if node is self._head:
             self._head = node.next
+            if self._head:
+                self._head.previous = None
+            if self._tail is self._head:
+                self._tail = None
         elif node is self._tail:
             self._tail = node.previous
+            if self._tail is self._head:
+                self._tail = None
+            if self._tail:
+                self._tail.next = None
         else:
             node.previous.next = node.next
             node.next.previous = node.previous

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, Extension
 
 setup(
     name='lruset',
-    version='0.1',
+    version='0.2',
     description="A fixed size set with LRU eviction.",
     license='BSD',
     author='James Saryerwinnie',

--- a/test_lruset.py
+++ b/test_lruset.py
@@ -6,6 +6,9 @@ import time
 import lruset
 import clruset
 
+import math
+import random
+
 
 class TestLRUSet(unittest.TestCase):
     def create_set(self, size):
@@ -215,6 +218,13 @@ class TestLRUSet(unittest.TestCase):
         del s
         del ob
         self.assertEqual(id(list(i)[-1]), ob_id)
+
+    def testRandom(self):
+        s = self.create_set(50)
+        for i in xrange(1000000):
+            a = str(int(math.sqrt(random.randrange(100000))))
+            if a not in s:
+                s.add(a)
 
 
 class TestCLRUSet(TestLRUSet):


### PR DESCRIPTION
It turns out that the python version of lruset crashes with a keyerror after some period of time. I added a test case that pretty reliably reproduces the problem. It turns out that the linked list which maintained the LRU was not be handled correctly and it had stray pointers and the like in it. This led to all sorts of problems which are now fixed by this PR.
